### PR TITLE
chore: 修复 TypeScript 对组件 md 导入提示仅表示类型，但在此处却作为值使用

### DIFF
--- a/demo/env.d.ts
+++ b/demo/env.d.ts
@@ -2,10 +2,12 @@
 
 declare module '*.md' {
   import type { ComponentType } from 'react';
-  export default ComponentType;
+  const Component: ComponentType;
+  export default Component;
 }
 
 declare module '*.markdown' {
   import type { ComponentType } from 'react';
-  export default ComponentType;
+  const Component: ComponentType;
+  export default Component;
 }


### PR DESCRIPTION
<img width="2148" alt="image" src="https://github.com/itsatan/yike-design-react/assets/50828665/e24a212a-4534-4208-bc69-a64e50f10fee">
